### PR TITLE
Slim down the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine
+FROM golang:1.26-alpine AS build
 
 WORKDIR /app
 
@@ -9,5 +9,10 @@ COPY go.sum ./
 RUN go mod download
 
 RUN go build ./cmd/main.go
+
+FROM alpine:latest AS final
+
+WORKDIR /app
+COPY --from=build /app/main /app/main
 
 CMD ["./main"]


### PR DESCRIPTION
# What does this do?
- Slims down the final docker image size from ~400MB to ~20MB through different build steps and only copying the binary into an alpine image

<img width="778" height="140" alt="image" src="https://github.com/user-attachments/assets/bd870fb1-e9a5-4488-9489-4d3d45638028" />
